### PR TITLE
add py.typed to project

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,6 @@ setup(
     ext_modules=cythonize(extensions, language_level=3),
     zip_safe=False,
     package_data={
-        "synthizer": ["*.pyx", "*.pxd", "synthizer.pyi"],
+        "synthizer": ["*.pyx", "*.pxd", "synthizer.pyi", "py.typed"],
     },
 )


### PR DESCRIPTION
A py.typed file needs to be added so that mypy recognizes a package to be actually typed.

This closes issue #11.

I have read CONTRIBUTING.md, am the sole contributor to this pull request, and license my contributions under the Unlicense.